### PR TITLE
Avoid __bool__ conversion of self.bias and use 'is not None' instead

### DIFF
--- a/DepthwiseConv3D.py
+++ b/DepthwiseConv3D.py
@@ -221,7 +221,7 @@ class DepthwiseConv3D(Conv3D):
                 data_format=self._data_format) for inp in inputs], axis=1 if format == 'NCDHW' else 4)
 
 
-        if self.bias:
+        if self.bias is not None:
             outputs = K.bias_add(
                 outputs,
                 self.bias,


### PR DESCRIPTION
Allows using eager execution model since otherwise the Tensor becomes a numpy array which can not be converted to bool.